### PR TITLE
Add ticks prop as an alias for tickArguments

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,6 +22,7 @@ function translateY(y: number) {
 
 export const Axis = <Domain extends AxisDomain>({
   scale,
+  ticks,
   tickArguments = [],
   tickValues = null,
   tickFormat = null,
@@ -50,6 +51,10 @@ export const Axis = <Domain extends AxisDomain>({
   if (tickSize) {
     tickSizeInner = tickSize;
     tickSizeOuter = tickSize;
+  }
+
+  if (ticks) {
+    tickArguments = ticks;
   }
 
   function number(scale: AxisScale<Domain>) {


### PR DESCRIPTION
For ease of directly translating from d3-axis to d3-axis-for-react, this aliases tickArguments to ticks. If you specify both, ticks wins.

https://github.com/d3/d3-axis/blob/4fc4f2bd287de20c4fc5f1da447ae1194d3acca6/src/axis.js#L122-L128