### PR TITLE
Allow all react versions over 16

### DIFF
--- a/__tests__/__snapshots__/axis.test.tsx.snap
+++ b/__tests__/__snapshots__/axis.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`axis with custom text props 1`] = `
 <g>

--- a/__tests__/axis.test.tsx
+++ b/__tests__/axis.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import renderer from "react-test-renderer";
 import { Axis, Orient } from "../src/index";
 import { scaleLinear } from "d3";
+import { test, expect } from "vitest";
 
 test("axis with default options", async () => {
   const scale = scaleLinear().domain([0, 1]).range([0, 1]);

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,7 +1,0 @@
-module.exports = {
-  presets: [
-    ["@babel/preset-env", { targets: { node: "current" } }],
-    "@babel/preset-react",
-    "@babel/preset-typescript",
-  ],
-};

--- a/docs/.nojekyll
+++ b/docs/.nojekyll
@@ -1,0 +1,1 @@
+TypeDoc added this file to prevent GitHub Pages from using Jekyll. You can turn off this behavior by setting the `githubPages` option to false.

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ d3-axis-for-react
 
 ### Enumerations
 
-- [Orient](enums/orient.md)
+- [Orient](enums/Orient.md)
 
 ### Functions
 
@@ -16,37 +16,41 @@ d3-axis-for-react
 
 ### Axis
 
-▸ `Const`**Axis**<Domain\>(`__namedParameters`: { `domainPathProps?`: *null* \| *SVGProps*<SVGPathElement\> ; `offset?`: *number* ; `orient?`: [*Orient*](enums/orient.md) ; `scale`: *AxisScale*<Domain\> ; `tickArguments?`: *any*[] ; `tickFormat?`: *any* ; `tickLineProps?`: *null* \| *SVGProps*<SVGLineElement\> ; `tickPadding?`: *number* ; `tickSize?`: *number* ; `tickSizeInner?`: *number* ; `tickSizeOuter?`: *number* ; `tickTextProps?`: *null* \| *SVGProps*<SVGTextElement\> ; `tickValues?`: *null* \| *any*[] ; `ticks?`: *any*[]  }): *Element*
+▸ **Axis**<`Domain`\>(`«destructured»`): `Element`
 
 The axis component. This renders an axis, within a
 `g` element, for use in a chart.
 
-#### Type parameters:
+#### Type parameters
 
-Name | Type |
-:------ | :------ |
-`Domain` | AxisDomain |
+| Name | Type |
+| :------ | :------ |
+| `Domain` | extends `AxisDomain` |
 
-#### Parameters:
+#### Parameters
 
-Name | Type | Description |
-:------ | :------ | :------ |
-`__namedParameters` | *object* | - |
-`__namedParameters.domainPathProps?` | *null* \| *SVGProps*<SVGPathElement\> | Additional attributes to the domain path, or null to omit   |
-`__namedParameters.offset?` | *number* | - |
-`__namedParameters.orient?` | [*Orient*](enums/orient.md) | - |
-`__namedParameters.scale` | *AxisScale*<Domain\> | An initialized d3 scale object, like a d3.linearScale   |
-`__namedParameters.tickArguments?` | *any*[] | - |
-`__namedParameters.tickFormat?` | *any* | - |
-`__namedParameters.tickLineProps?` | *null* \| *SVGProps*<SVGLineElement\> | Additional attributes to add to tick line elements, or null to omit   |
-`__namedParameters.tickPadding?` | *number* | - |
-`__namedParameters.tickSize?` | *number* | - |
-`__namedParameters.tickSizeInner?` | *number* | - |
-`__namedParameters.tickSizeOuter?` | *number* | - |
-`__namedParameters.tickTextProps?` | *null* \| *SVGProps*<SVGTextElement\> | Additional attributes to add to tick text elements, or null to omit   |
-`__namedParameters.tickValues?` | *null* \| *any*[] | - |
-`__namedParameters.ticks?` | *any*[] | - |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `«destructured»` | `Object` | - |
+| › `domainPathProps?` | ``null`` \| `SVGProps`<`SVGPathElement`\> | Additional attributes to the domain path, or null to omit |
+| › `offset?` | `number` | - |
+| › `orient?` | [`Orient`](enums/Orient.md) | - |
+| › `scale` | `AxisScale`<`Domain`\> | An initialized d3 scale object, like a d3.linearScale |
+| › `tickArguments?` | `any`[] | - |
+| › `tickFormat?` | `any` | - |
+| › `tickLineProps?` | ``null`` \| `SVGProps`<`SVGLineElement`\> | Additional attributes to add to tick line elements, or null to omit |
+| › `tickPadding?` | `number` | - |
+| › `tickSize?` | `number` | - |
+| › `tickSizeInner?` | `number` | - |
+| › `tickSizeOuter?` | `number` | - |
+| › `tickTextProps?` | ``null`` \| `SVGProps`<`SVGTextElement`\> | Additional attributes to add to tick text elements, or null to omit |
+| › `tickValues?` | ``null`` \| `any`[] | - |
+| › `ticks?` | `any`[] | - |
 
-**Returns:** *Element*
+#### Returns
 
-Defined in: [index.tsx:33](https://github.com/tmcw/d3-axis-for-react/blob/c9e22a5/src/index.tsx#L33)
+`Element`
+
+#### Defined in
+
+[index.tsx:33](https://github.com/tmcw/d3-axis-for-react/blob/7123c8d/src/index.tsx#L33)

--- a/docs/enums/orient.md
+++ b/docs/enums/orient.md
@@ -9,41 +9,49 @@ to place the axis on the left.
 
 ## Table of contents
 
-### Enumeration members
+### Enumeration Members
 
-- [bottom](orient.md#bottom)
-- [left](orient.md#left)
-- [right](orient.md#right)
-- [top](orient.md#top)
+- [bottom](Orient.md#bottom)
+- [left](Orient.md#left)
+- [right](Orient.md#right)
+- [top](Orient.md#top)
 
-## Enumeration members
+## Enumeration Members
 
 ### bottom
 
-• **bottom**: = 3
+• **bottom** = ``3``
 
-Defined in: [index.tsx:17](https://github.com/tmcw/d3-axis-for-react/blob/c9e22a5/src/index.tsx#L17)
+#### Defined in
+
+[index.tsx:17](https://github.com/tmcw/d3-axis-for-react/blob/7123c8d/src/index.tsx#L17)
 
 ___
 
 ### left
 
-• **left**: = 4
+• **left** = ``4``
 
-Defined in: [index.tsx:18](https://github.com/tmcw/d3-axis-for-react/blob/c9e22a5/src/index.tsx#L18)
+#### Defined in
+
+[index.tsx:18](https://github.com/tmcw/d3-axis-for-react/blob/7123c8d/src/index.tsx#L18)
 
 ___
 
 ### right
 
-• **right**: = 2
+• **right** = ``2``
 
-Defined in: [index.tsx:16](https://github.com/tmcw/d3-axis-for-react/blob/c9e22a5/src/index.tsx#L16)
+#### Defined in
+
+[index.tsx:16](https://github.com/tmcw/d3-axis-for-react/blob/7123c8d/src/index.tsx#L16)
 
 ___
 
 ### top
 
-• **top**: = 1
+• **top** = ``1``
 
-Defined in: [index.tsx:15](https://github.com/tmcw/d3-axis-for-react/blob/c9e22a5/src/index.tsx#L15)
+#### Defined in
+
+[index.tsx:15](https://github.com/tmcw/d3-axis-for-react/blob/7123c8d/src/index.tsx#L15)

--- a/package.json
+++ b/package.json
@@ -13,36 +13,32 @@
     "dist"
   ],
   "scripts": {
-    "test": "tsc && jest",
+    "test": "tsc && vitest run",
     "build": "microbundle  --jsx React.createElement --no-compress && npm run doc",
     "doc": "typedoc --plugin typedoc-plugin-markdown --readme none src/index.tsx",
     "prepare": "npm run build",
     "release": "standard-version"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0-rc.1",
-    "react-dom": "^16.8.0 || ^17.0.0-rc.1"
+    "react": ">= 16",
+    "react-dom": ">= 16"
   },
   "devDependencies": {
-    "@babel/preset-env": "^7.13.15",
-    "@babel/preset-react": "^7.13.13",
-    "@babel/preset-typescript": "^7.13.0",
-    "@types/d3": "^6.3.0",
-    "@types/d3-axis": "^2.0.0",
-    "@types/jest": "^26.0.22",
-    "@types/react": "^17.0.3",
-    "@types/react-test-renderer": "^17.0.1",
-    "babel-jest": "^26.6.3",
-    "d3": "^6.6.2",
-    "eslint": "^7.24.0",
-    "jest": "^26.6.3",
-    "microbundle": "^0.13.0",
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0",
-    "react-test-renderer": "^17.0.2",
-    "standard-version": "^9.2.0",
-    "typedoc": "^0.20.35",
-    "typedoc-plugin-markdown": "^3.6.1",
-    "typescript": "^4.2.4"
+    "@types/d3": "^7.4.0",
+    "@types/d3-axis": "^3.0.2",
+    "@types/jest": "^29.5.3",
+    "@types/react": "^18.2.14",
+    "@types/react-test-renderer": "^18.0.0",
+    "d3": "^7.8.5",
+    "eslint": "^8.44.0",
+    "microbundle": "^0.15.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-test-renderer": "^18.2.0",
+    "standard-version": "^9.5.0",
+    "typedoc": "^0.24.8",
+    "typedoc-plugin-markdown": "^3.15.3",
+    "vitest": "^0.33.0",
+    "typescript": "^5.1.6"
   }
 }


### PR DESCRIPTION
- Fixes #11

Also some mild housekeeping:

- Bump all the dependencies
- Switch from jest to vitest, as I have in all my projects